### PR TITLE
Support GZIP compression in `write_parquet()`.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,8 @@
 
 * `read_parquet()` can now read Parquet files with V2 data pages (#37).
 
-* `read_parquet()` can now read GZIP compressed Parquet files.
+* Both `read_parquet()` and `write_parquet()` now support GZIP compressed
+  Parquet files.
 
 * `read_parquet()` can now read Parquet files with `BOOLEAN` columns in
   `RLE` encoding.

--- a/R/nanoparquet.R
+++ b/R/nanoparquet.R
@@ -424,7 +424,7 @@ parquet_columns <- function(file) {
 #'   then the data frame is written to a memory buffer, and the memory
 #'   buffer is returned as a raw vector.
 #' @param compression Compression algorithm to use. Currently only
-#'   `"snappy"` (the default) and `"uncompressed"` are supported.
+#'   `"snappy"` (the default), `"gzip"` and `"uncompressed"` are supported.
 #' @param metadata Additional key-value metadata to add to the file.
 #'   This must be a named character vector, or a data frame with columns
 #'   character columns called `key` and `value`.
@@ -441,11 +441,11 @@ parquet_columns <- function(file) {
 write_parquet <- function(
 	x,
 	file,
-	compression = c("snappy", "uncompressed"),
+	compression = c("snappy", "gzip", "uncompressed"),
 	metadata = NULL) {
 
   file <- path.expand(file)
-	codecs <- c("uncompressed" = 0L, "snappy" = 1L)
+	codecs <- c("uncompressed" = 0L, "snappy" = 1L, "gzip" = 2L)
 	compression <- codecs[match.arg(compression)]
 	dim <- as.integer(dim(x))
 

--- a/man/write_parquet.Rd
+++ b/man/write_parquet.Rd
@@ -7,7 +7,7 @@
 write_parquet(
   x,
   file,
-  compression = c("snappy", "uncompressed"),
+  compression = c("snappy", "gzip", "uncompressed"),
   metadata = NULL
 )
 }
@@ -19,7 +19,7 @@ then the data frame is written to a memory buffer, and the memory
 buffer is returned as a raw vector.}
 
 \item{compression}{Compression algorithm to use. Currently only
-\code{"snappy"} (the default) and \code{"uncompressed"} are supported.}
+\code{"snappy"} (the default), \code{"gzip"} and \code{"uncompressed"} are supported.}
 
 \item{metadata}{Additional key-value metadata to add to the file.
 This must be a named character vector, or a data frame with columns

--- a/src/write.cpp
+++ b/src/write.cpp
@@ -778,6 +778,9 @@ SEXP nanoparquet_write(
     case 1:
       codec = parquet::format::CompressionCodec::SNAPPY;
       break;
+    case 2:
+      codec = parquet::format::CompressionCodec::GZIP;
+      break;
     default:
       Rf_error("Invalid compression type code: %d", c_compression); // # nocov
       break;

--- a/tests/testthat/test-write-parquet-2.R
+++ b/tests/testthat/test-write-parquet-2.R
@@ -117,3 +117,13 @@ test_that("write_parquet() to memory", {
 
   expect_equal(pm, pm2)
 })
+
+test_that("gzip compression", {
+  d <- test_df(missing = TRUE)
+  tmp <- tempfile(fileext = ".parquet")
+  on.exit(unlink(tmp), add = TRUE)
+
+  write_parquet(d, tmp, compression = "gzip")
+  expect_equal(read_parquet_page(tmp, 4L)$codec, "GZIP")
+  expect_equal(read_parquet(tmp), d);
+})


### PR DESCRIPTION
Closes #55.