### PR TITLE
`read_parquet()` can read from a connection now

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,6 +53,8 @@
 * `write_parquet(file = ":raw:")` now works correctly for larger data
   frames (#77).
 
+* `read_parquet()` can now read from an R connection (#71).
+
 * `read_parquet()` now reads `DECIMAL` values correctly from `INT32`
   and `INT64` columns if their `scale` is not zero.
 

--- a/man/read_parquet.Rd
+++ b/man/read_parquet.Rd
@@ -7,7 +7,12 @@
 read_parquet(file, options = parquet_options())
 }
 \arguments{
-\item{file}{Path to a Parquet file.}
+\item{file}{Path to a Parquet file. It may also be an R connection,
+in which case it first reads all data from the connection, writes
+it into a temporary file, then reads the temporary file, and
+deletes it. The connection might be open, it which case it must be
+a binary connection. If it is not open, then \code{read_parquet()} will
+open it and also close it in the end.}
 
 \item{options}{Nanoparquet options, see \code{\link[=parquet_options]{parquet_options()}}.}
 }

--- a/tests/testthat/test-read-parquet-connection.R
+++ b/tests/testthat/test-read-parquet-connection.R
@@ -1,0 +1,33 @@
+test_that("not open", {
+  pf <- test_path("data/factor.parquet")
+  con <- file(pf)
+  expect_equal(
+    read_parquet(con),
+    read_parquet(pf)
+  )
+  # A closed (=invalid in R) connection will error here
+  expect_error(isOpen(con))
+})
+
+test_that("open", {
+  pf <- test_path("data/factor.parquet")
+  con <- file(pf, open = "rb")
+  on.exit(close(con), add = TRUE)
+  expect_equal(
+    read_parquet(con),
+    read_parquet(pf)
+  )
+  expect_true(isOpen(con))
+})
+
+test_that("raw, opened", {
+  pf <- test_path("data/factor.parquet")
+  bts <- readBin(pf, what = "raw", n = file.size(pf))
+  con <- rawConnection(bts, open = "rb")
+  on.exit(close(con), add = TRUE)
+  expect_equal(
+    read_parquet(con),
+    read_parquet(pf)
+  )
+  expect_true(isOpen(con))
+})


### PR DESCRIPTION
Partially addresses #71.