### PR TITLE
Fix compilation with older XCode 14.2

### DIFF
--- a/src/RParquetReader.cpp
+++ b/src/RParquetReader.cpp
@@ -1,4 +1,4 @@
-#include <math.h>
+#include <cmath>
 
 #include "RParquetReader.h"
 #include "protect.h"


### PR DESCRIPTION
Apparently this is what CRAN uses. I can't install it on my macOS, I had to check it on Monterey, with tart.