### PR TITLE
fix: sub-day precision Date should be floored when treated as integer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # nanoparquet (development version)
 
+* `write_parquet()` now correctly converts double `Date` columns
+  to integer columns (@eitsupi, #116).
+
 # nanoparquet 0.4.0
 
 * API changes:

--- a/R/write-parquet.R
+++ b/R/write-parquet.R
@@ -162,9 +162,14 @@ prepare_write_df <- function(x) {
   }
 
   # Date must be integer
-  double_dates <- which(vapply(x, function(x) inherits(x, "Date") && is.double(x), FUN.VALUE = logical(1)))
+  double_dates <- which(vapply(x, FUN.VALUE = logical(1), function(x) {
+    inherits(x, "Date") && is.double(x)
+  }))
   for (idx in double_dates) {
-    x[[idx]] <- .Date(as.integer(floor(as.numeric(x[[idx]]))))
+    cls <- class(x[[idx]])
+    xi <- as.integer(floor(as.numeric(x[[idx]])))
+    class(xi) <- cls
+    x[[idx]] <- xi
   }
 
   # Convert hms to double
@@ -191,7 +196,7 @@ prepare_write_df <- function(x) {
   }
 
   x
-}
+  }
 
 check_schema_required_cols <- function(x, schema) {
   # if schema has REQUIRED, but the column has NAs, that's an error

--- a/R/write-parquet.R
+++ b/R/write-parquet.R
@@ -162,10 +162,9 @@ prepare_write_df <- function(x) {
   }
 
   # Date must be integer
-  dates <- which(vapply(x, "inherits", "Date", FUN.VALUE = logical(1)))
-  for (idx in dates) {
-    # this keeps the class
-    mode(x[[idx]]) <- "integer"
+  double_dates <- which(vapply(x, function(x) inherits(x, "Date") && is.double(x), FUN.VALUE = logical(1)))
+  for (idx in double_dates) {
+    x[[idx]] <- .Date(as.integer(floor(as.numeric(x[[idx]]))))
   }
 
   # Convert hms to double

--- a/tests/testthat/test-write-parquet-2.R
+++ b/tests/testthat/test-write-parquet-2.R
@@ -186,3 +186,18 @@ test_that("zstd compression", {
   expect_equal(read_parquet_page(tmp, 4L)$codec, "ZSTD")
   expect_equal(read_parquet(tmp), d);
 })
+
+test_that("Conversion of sub-dates prior Posix origin is correct", {
+  data <- data.frame(
+    days = as.Date(c(-1.1, -0.1, 0, 0.1, 1.1), origin = "1970-01-01")
+  )
+
+  tmp <- tempfile(fileext = ".parquet")
+  on.exit(unlink(tmp), add = TRUE)
+
+  write_parquet(data, tmp)
+  expect_equal(
+    as.character(as.data.frame(read_parquet(tmp))$date),
+    as.character(data$date)
+  )
+})


### PR DESCRIPTION
Same as apache/arrow-nanoarrow#674, duckdb/duckdb-r#981

Because the Date type in R allows sub-days, it must be rounded to -Inf before being forced to integerish.
Conventional rounding in the direction of zero would change the direction of rounding before and after Unix origin.