### PR TITLE
`read_parquet()` from URL

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # nanoparquet (development version)
 
+* `read_parquet()` can now read files from URLs.
+
 # nanoparquet 0.4.2
 
 * `write_parquet()` now does not fail when writing files with a zero-length

--- a/R/read-parquet.R
+++ b/R/read-parquet.R
@@ -32,6 +32,11 @@ read_parquet <- function(file, col_select = NULL,
 		on.exit(unlink(tmp), add = TRUE)
 		dump_connection(file, tmp)
 		file <- tmp
+	} else if (is.character(file) && length(file) == 1 && any(startsWith(file, c("https://", "http://")))) { 
+		tmp <- tempfile(fileext = ".parquet")
+		on.exit(unlink(tmp), add = TRUE)
+		suppressWarnings(download.file(file, destfile = tmp, quiet = TRUE, mode = "wb"))
+		file <- tmp
 	}
   file <- path.expand(file)
 


### PR DESCRIPTION
Support for URLs in `read_parquet()`.

``` r
library(nanoparquet)

# good URL
dat <- read_parquet("https://marginaleffects.com/data/thornton.parquet")
head(dat)
#>   village outcome  distance amount incentive age hiv2004 agecat
#> 1      43       1 0.5485229      0         0  14       0    <18
#> 2     117       0 0.8402644      0         0  14       0    <18
#> 3       2       0 3.3421636      0         0  15       0    <18
#> 4       6       0 2.3228946      0         0  15       0    <18
#> 5      11       0 1.3862627      0         0  15       0    <18
#> 6      14       0 3.8656266      0         0  15       0    <18

# bad URL
dat <- read_parquet("https://perdu.com/badfile.parquet")
#> Error in download.file(file, destfile = tmp, quiet = TRUE, mode = "wb"): cannot open URL 'https://perdu.com/badfile.parquet'
```
