### PR TITLE
Read/write blob::blob

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ Encoding: UTF-8
 Suggests:
     arrow,
     bit64,
+    blob,
     DBI,
     duckdb (>= 1.4.0),
     hms,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # nanoparquet (development version)
 
+* `read_parquet()` now returns `BYTE_ARRAY` and `FIXED_LEN_BYTE_ARRAY`
+  columns (without a string/UUID/decimal annotation) as `blob::blob` objects
+  instead of plain lists of raw vectors. `write_parquet()` now also accepts
+  `blob::blob` columns (#115).
+
 * `read_parquet()` can now read empty data frames (zero rows) written by the
   arrow package (#160).
 

--- a/R/parquet-column-types.R
+++ b/R/parquet-column-types.R
@@ -61,8 +61,8 @@ add_r_type_to_schema <- function(mtd, sch, options, col_select = NULL) {
     DOUBLE = "double",
     FLOAT = "double",
     INT96 = "POSIXct",
-    FIXED_LEN_BYTE_ARRAY = "raw",
-    BYTE_ARRAY = "raw"
+    FIXED_LEN_BYTE_ARRAY = "blob",
+    BYTE_ARRAY = "blob"
   )
 
   sch$r_type <- unname(type_map[sch$type])

--- a/R/read-parquet.R
+++ b/R/read-parquet.R
@@ -143,6 +143,12 @@ post_process_read_result <- function(res, file, options, col_select) {
     }
   }
 
+  # add ptype attribute to blob columns for vctrs compatibility
+  blobs <- which(vapply(res, "inherits", "blob", FUN.VALUE = logical(1)))
+  for (idx in blobs) {
+    attr(res[[idx]], "ptype") <- raw()
+  }
+
   # convert hms from milliseconds to seconds, also integer -> double
   hmss <- which(vapply(res, "inherits", "hms", FUN.VALUE = logical(1)))
   for (idx in hmss) {

--- a/src/RParquetReader.cpp
+++ b/src/RParquetReader.cpp
@@ -444,6 +444,10 @@ rtype::rtype(
       type = VECSXP;
       tmptype = NILSXP;
       type_conversion = BA_RAW;
+      classes.push_back("blob");
+      classes.push_back("vctrs_list_of");
+      classes.push_back("vctrs_vctr");
+      classes.push_back("list");
     }
     break;
   }

--- a/src/cpp-utils.cpp
+++ b/src/cpp-utils.cpp
@@ -182,8 +182,10 @@ nanoparquet::SchemaElementEx nanoparquet_map_to_parquet_type_vecsxp(
 
   // Find a representative element to determine the atomic type
   SEXP elt = R_NilValue;
+  bool is_blob = false;
   r_call([&] {
     R_xlen_t len = Rf_xlength(x);
+    is_blob = Rf_inherits(x, "blob");
     for (R_xlen_t i = 0; i < len; i++) {
       SEXP e = VECTOR_ELT(x, i);
       if (!Rf_isNull(e) && Rf_xlength(e) > 0) {
@@ -194,7 +196,7 @@ nanoparquet::SchemaElementEx nanoparquet_map_to_parquet_type_vecsxp(
   });
 
   int elt_type = TYPEOF(elt);
-  if (!Rf_isNull(elt) && elt_type != VECSXP && elt_type != RAWSXP) {
+  if (!is_blob && !Rf_isNull(elt) && elt_type != VECSXP && elt_type != RAWSXP) {
     // Atomic element type: build a 3-layer LIST schema
     std::string inner_rtype;
     nanoparquet::SchemaElementEx inner =
@@ -226,7 +228,7 @@ nanoparquet::SchemaElementEx nanoparquet_map_to_parquet_type_vecsxp(
   }
 
   // VECSXP, RAWSXP, or empty list: single BYTE_ARRAY column
-  rtype = "raw";
+  rtype = is_blob ? "blob" : "raw";
   parquet::SchemaElement sel;
   sel.__set_name(name);
   sel.__set_repetition_type(

--- a/tests/testthat/_snaps/parquet-metadata.md
+++ b/tests/testthat/_snaps/parquet-metadata.md
@@ -178,22 +178,22 @@
       13 data/enum.parquet     7                v_int64
       14 data/enum.parquet     7              v_float64
       15 data/enum.parquet     7               v_binary
-                                                                            r_type
-      1                                                                       <NA>
-      2                                                                        raw
-      3                                                                        raw
-      4                                                                        raw
-      5                                                                  character
-      6                                                                     double
-      7                                                                     double
-      8  list(list(character, character, character, logical, double, double, raw))
-      9                                                                       <NA>
-      10                                                                      <NA>
-      11                                                                      <NA>
-      12                                                                      <NA>
-      13                                                                      <NA>
-      14                                                                      <NA>
-      15                                                                      <NA>
+                                                                             r_type
+      1                                                                        <NA>
+      2                                                                        blob
+      3                                                                        blob
+      4                                                                        blob
+      5                                                                   character
+      6                                                                      double
+      7                                                                      double
+      8  list(list(character, character, character, logical, double, double, blob))
+      9                                                                        <NA>
+      10                                                                       <NA>
+      11                                                                       <NA>
+      12                                                                       <NA>
+      13                                                                       <NA>
+      14                                                                       <NA>
+      15                                                                       <NA>
                type type_length repetition_type converted_type logical_type
       1        <NA>          NA            <NA>           <NA>             
       2  BYTE_ARRAY          NA        OPTIONAL           <NA>             

--- a/tests/testthat/_snaps/read-parquet-2.md
+++ b/tests/testthat/_snaps/read-parquet-2.md
@@ -701,7 +701,7 @@
     Output
         r_col   name r_type       type type_length repetition_type converted_type
       1    NA schema   <NA>       <NA>          NA            <NA>           <NA>
-      2     1      l    raw BYTE_ARRAY          NA        REQUIRED           <NA>
+      2     1      l   blob BYTE_ARRAY          NA        REQUIRED           <NA>
         logical_type num_children scale precision field_id children
       1                         1    NA        NA       NA         
       2                        NA    NA        NA       NA         
@@ -721,7 +721,7 @@
     Output
         r_col   name r_type       type type_length repetition_type converted_type
       1    NA schema   <NA>       <NA>          NA            <NA>           <NA>
-      2     1      l    raw BYTE_ARRAY          NA        OPTIONAL           <NA>
+      2     1      l   blob BYTE_ARRAY          NA        OPTIONAL           <NA>
         logical_type num_children scale precision field_id children
       1                         1    NA        NA       NA         
       2                        NA    NA        NA       NA         
@@ -788,7 +788,7 @@
     Output
         r_col   name r_type                 type type_length repetition_type
       1    NA schema   <NA>                 <NA>          NA            <NA>
-      2     1      l    raw FIXED_LEN_BYTE_ARRAY          10        REQUIRED
+      2     1      l   blob FIXED_LEN_BYTE_ARRAY          10        REQUIRED
         converted_type logical_type num_children scale precision field_id children
       1           <NA>                         1    NA        NA       NA         
       2           <NA>                        NA    NA        NA       NA         
@@ -808,7 +808,7 @@
     Output
         r_col   name r_type                 type type_length repetition_type
       1    NA schema   <NA>                 <NA>          NA            <NA>
-      2     1      l    raw FIXED_LEN_BYTE_ARRAY          10        OPTIONAL
+      2     1      l   blob FIXED_LEN_BYTE_ARRAY          10        OPTIONAL
         converted_type logical_type num_children scale precision field_id children
       1           <NA>                         1    NA        NA       NA         
       2           <NA>                        NA    NA        NA       NA         
@@ -832,7 +832,7 @@
     Output
         r_col   name r_type                 type type_length repetition_type
       1    NA schema   <NA>                 <NA>          NA            <NA>
-      2     1      s    raw FIXED_LEN_BYTE_ARRAY           3        REQUIRED
+      2     1      s   blob FIXED_LEN_BYTE_ARRAY           3        REQUIRED
         converted_type logical_type num_children scale precision field_id children
       1           <NA>                         1    NA        NA       NA         
       2           <NA>                        NA    NA        NA       NA         
@@ -855,7 +855,7 @@
     Output
         r_col   name r_type                 type type_length repetition_type
       1    NA schema   <NA>                 <NA>          NA            <NA>
-      2     1      s    raw FIXED_LEN_BYTE_ARRAY           3        OPTIONAL
+      2     1      s   blob FIXED_LEN_BYTE_ARRAY           3        OPTIONAL
         converted_type logical_type num_children scale precision field_id children
       1           <NA>                         1    NA        NA       NA         
       2           <NA>                        NA    NA        NA       NA         

--- a/tests/testthat/_snaps/read-parquet.md
+++ b/tests/testthat/_snaps/read-parquet.md
@@ -502,7 +502,7 @@
     Output
                                      file_name r_col   name r_type
       1 data/float16_nonzeros_and_nans.parquet    NA schema   <NA>
-      2 data/float16_nonzeros_and_nans.parquet     1      x    raw
+      2 data/float16_nonzeros_and_nans.parquet     1      x   blob
                         type type_length repetition_type converted_type logical_type
       1                 <NA>          NA        REQUIRED           <NA>             
       2 FIXED_LEN_BYTE_ARRAY           2        OPTIONAL           <NA>      FLOAT16

--- a/tests/testthat/_snaps/write-parquet-3.md
+++ b/tests/testthat/_snaps/write-parquet-3.md
@@ -688,7 +688,7 @@
     Output
         r_col   name r_type       type type_length repetition_type converted_type
       1    NA schema   <NA>       <NA>          NA            <NA>           <NA>
-      2     1      d    raw BYTE_ARRAY          NA        OPTIONAL           <NA>
+      2     1      d   blob BYTE_ARRAY          NA        OPTIONAL           <NA>
         logical_type num_children scale precision field_id children
       1                         1    NA        NA       NA         
       2                        NA    NA        NA       NA         
@@ -708,7 +708,7 @@
     Output
         r_col   name r_type                 type type_length repetition_type
       1    NA schema   <NA>                 <NA>          NA            <NA>
-      2     1      d    raw FIXED_LEN_BYTE_ARRAY           3        OPTIONAL
+      2     1      d   blob FIXED_LEN_BYTE_ARRAY           3        OPTIONAL
         converted_type logical_type num_children scale precision field_id children
       1           <NA>                         1    NA        NA       NA         
       2           <NA>                        NA    NA        NA       NA         
@@ -1638,7 +1638,7 @@
     Output
         r_col   name r_type       type type_length repetition_type converted_type
       1    NA schema   <NA>       <NA>          NA            <NA>           <NA>
-      2     1      d    raw BYTE_ARRAY          NA        OPTIONAL           JSON
+      2     1      d   blob BYTE_ARRAY          NA        OPTIONAL           JSON
         logical_type num_children scale precision field_id children
       1                         1    NA        NA       NA         
       2         JSON           NA    NA        NA       NA         
@@ -1686,7 +1686,7 @@
     Output
         r_col   name r_type                 type type_length repetition_type
       1    NA schema   <NA>                 <NA>          NA            <NA>
-      2     1      c    raw FIXED_LEN_BYTE_ARRAY           2        OPTIONAL
+      2     1      c   blob FIXED_LEN_BYTE_ARRAY           2        OPTIONAL
         converted_type logical_type num_children scale precision field_id children
       1           <NA>                         1    NA        NA       NA         
       2           <NA>      FLOAT16           NA    NA        NA       NA         
@@ -1733,7 +1733,7 @@
     Output
         r_col   name r_type       type type_length repetition_type converted_type
       1    NA schema   <NA>       <NA>          NA            <NA>           <NA>
-      2     1      d    raw BYTE_ARRAY          NA        REQUIRED           <NA>
+      2     1      d   blob BYTE_ARRAY          NA        REQUIRED           <NA>
         logical_type num_children scale precision field_id children
       1                         1    NA        NA       NA         
       2                        NA    NA        NA       NA         
@@ -1752,7 +1752,7 @@
     Output
         r_col   name r_type       type type_length repetition_type converted_type
       1    NA schema   <NA>       <NA>          NA            <NA>           <NA>
-      2     1      d    raw BYTE_ARRAY          NA        OPTIONAL           <NA>
+      2     1      d   blob BYTE_ARRAY          NA        OPTIONAL           <NA>
         logical_type num_children scale precision field_id children
       1                         1    NA        NA       NA         
       2                        NA    NA        NA       NA         
@@ -1773,7 +1773,7 @@
     Output
         r_col   name r_type                 type type_length repetition_type
       1    NA schema   <NA>                 <NA>          NA            <NA>
-      2     1      d    raw FIXED_LEN_BYTE_ARRAY           3        REQUIRED
+      2     1      d   blob FIXED_LEN_BYTE_ARRAY           3        REQUIRED
         converted_type logical_type num_children scale precision field_id children
       1           <NA>                         1    NA        NA       NA         
       2           <NA>                        NA    NA        NA       NA         
@@ -1792,7 +1792,7 @@
     Output
         r_col   name r_type                 type type_length repetition_type
       1    NA schema   <NA>                 <NA>          NA            <NA>
-      2     1      d    raw FIXED_LEN_BYTE_ARRAY           3        OPTIONAL
+      2     1      d   blob FIXED_LEN_BYTE_ARRAY           3        OPTIONAL
         converted_type logical_type num_children scale precision field_id children
       1           <NA>                         1    NA        NA       NA         
       2           <NA>                        NA    NA        NA       NA         
@@ -1805,4 +1805,84 @@
       3 62, 61, 72
       4 61, 61, 61
       5       NULL
+
+# blob::blob to BYTE_ARRAY
+
+    Code
+      as.data.frame(read_parquet_schema(tmp)[, -1])
+    Output
+        r_col   name r_type       type type_length repetition_type converted_type
+      1    NA schema   <NA>       <NA>          NA            <NA>           <NA>
+      2     1      d   blob BYTE_ARRAY          NA        REQUIRED           <NA>
+        logical_type num_children scale precision field_id children
+      1                         1    NA        NA       NA         
+      2                        NA    NA        NA       NA         
+    Code
+      as.data.frame(read_parquet(tmp))
+    Output
+                d
+      1 blob[3 B]
+      2 blob[3 B]
+      3 blob[6 B]
+
+---
+
+    Code
+      as.data.frame(read_parquet_schema(tmp)[, -1])
+    Output
+        r_col   name r_type       type type_length repetition_type converted_type
+      1    NA schema   <NA>       <NA>          NA            <NA>           <NA>
+      2     1      d   blob BYTE_ARRAY          NA        OPTIONAL           <NA>
+        logical_type num_children scale precision field_id children
+      1                         1    NA        NA       NA         
+      2                        NA    NA        NA       NA         
+    Code
+      as.data.frame(read_parquet(tmp))
+    Output
+                d
+      1 blob[3 B]
+      2      <NA>
+      3 blob[3 B]
+      4 blob[6 B]
+      5      <NA>
+
+# blob::blob to FIXED_LEN_BYTE_ARRAY
+
+    Code
+      as.data.frame(read_parquet_schema(tmp)[, -1])
+    Output
+        r_col   name r_type                 type type_length repetition_type
+      1    NA schema   <NA>                 <NA>          NA            <NA>
+      2     1      d   blob FIXED_LEN_BYTE_ARRAY           3        REQUIRED
+        converted_type logical_type num_children scale precision field_id children
+      1           <NA>                         1    NA        NA       NA         
+      2           <NA>                        NA    NA        NA       NA         
+    Code
+      as.data.frame(read_parquet(tmp))
+    Output
+                d
+      1 blob[3 B]
+      2 blob[3 B]
+      3 blob[3 B]
+
+---
+
+    Code
+      as.data.frame(read_parquet_schema(tmp)[, -1])
+    Output
+        r_col   name r_type                 type type_length repetition_type
+      1    NA schema   <NA>                 <NA>          NA            <NA>
+      2     1      d   blob FIXED_LEN_BYTE_ARRAY           3        OPTIONAL
+        converted_type logical_type num_children scale precision field_id children
+      1           <NA>                         1    NA        NA       NA         
+      2           <NA>                        NA    NA        NA       NA         
+    Code
+      as.data.frame(read_parquet(tmp))
+    Output
+                d
+      1 blob[3 B]
+      2      <NA>
+      3 blob[3 B]
+      4 blob[3 B]
+      5      <NA>
 

--- a/tests/testthat/test-read-parquet-5.R
+++ b/tests/testthat/test-read-parquet-5.R
@@ -227,8 +227,12 @@ test_that("mixing RLE_DICTIONARY and PLAIN, BYTE_ARRAY", {
   })
   t1 <- as.data.frame(read_parquet(pf))
   t2 <- as.data.frame(arrow::read_parquet(pf))
-  expect_equal(t1[, 1], unclass(t2[, 1]))
-  expect_equal(t1[, 2], unclass(t2[, 2]))
+  expect_equal(unclass(t1[, 1]), unclass(t2[, 1]), ignore_attr = TRUE)
+  expect_equal(unclass(t1[, 2]), unclass(t2[, 2]), ignore_attr = TRUE)
+  expect_s3_class(t1[, 1], "blob")
+  expect_s3_class(t1[, 2], "blob")
+  expect_identical(attr(t1[, 1], "ptype"), raw())
+  expect_identical(attr(t1[, 2], "ptype"), raw())
 })
 
 test_that("mixing RLE_DICTIONARY and PLAIN, FLOAT16", {

--- a/tests/testthat/test-write-parquet-3.R
+++ b/tests/testthat/test-write-parquet-3.R
@@ -712,3 +712,86 @@ test_that("list of RAW to FIXED_LEN_BYTE_ARRAY", {
     as.data.frame(read_parquet(tmp))
   })
 })
+
+test_that("blob::blob to BYTE_ARRAY", {
+  skip_without("blob")
+  tmp <- tempfile(fileext = ".parquet")
+  on.exit(unlink(tmp), add = TRUE)
+
+  d <- data.frame(
+    d = blob::blob(
+      charToRaw("foo"),
+      charToRaw("bar"),
+      charToRaw("foobar")
+    )
+  )
+  write_parquet(d, tmp)
+  expect_snapshot({
+    as.data.frame(read_parquet_schema(tmp)[, -1])
+    as.data.frame(read_parquet(tmp))
+  })
+  d2 <- read_parquet(tmp)
+  expect_s3_class(d2$d, "blob")
+  expect_equal(d2$d, d$d)
+
+  # with NAs (NULL entries in blob)
+  d_na <- data.frame(
+    d = blob::blob(
+      charToRaw("foo"),
+      NULL,
+      charToRaw("bar"),
+      charToRaw("foobar"),
+      NULL
+    )
+  )
+  write_parquet(d_na, tmp)
+  expect_snapshot({
+    as.data.frame(read_parquet_schema(tmp)[, -1])
+    as.data.frame(read_parquet(tmp))
+  })
+  d3 <- read_parquet(tmp)
+  expect_s3_class(d3$d, "blob")
+  expect_equal(d3$d, d_na$d)
+})
+
+test_that("blob::blob to FIXED_LEN_BYTE_ARRAY", {
+  skip_without("blob")
+  tmp <- tempfile(fileext = ".parquet")
+  on.exit(unlink(tmp), add = TRUE)
+  schema <- parquet_schema(list("FIXED_LEN_BYTE_ARRAY", type_length = 3))
+
+  d <- data.frame(
+    d = blob::blob(
+      charToRaw("foo"),
+      charToRaw("bar"),
+      charToRaw("aaa")
+    )
+  )
+  write_parquet(d, tmp, schema = schema)
+  expect_snapshot({
+    as.data.frame(read_parquet_schema(tmp)[, -1])
+    as.data.frame(read_parquet(tmp))
+  })
+  d2 <- read_parquet(tmp)
+  expect_s3_class(d2$d, "blob")
+  expect_equal(d2$d, d$d)
+
+  # with NAs
+  d_na <- data.frame(
+    d = blob::blob(
+      charToRaw("foo"),
+      NULL,
+      charToRaw("bar"),
+      charToRaw("aaa"),
+      NULL
+    )
+  )
+  write_parquet(d_na, tmp, schema = schema)
+  expect_snapshot({
+    as.data.frame(read_parquet_schema(tmp)[, -1])
+    as.data.frame(read_parquet(tmp))
+  })
+  d3 <- read_parquet(tmp)
+  expect_s3_class(d3$d, "blob")
+  expect_equal(d3$d, d_na$d)
+})

--- a/tools/types.Rmd
+++ b/tools/types.Rmd
@@ -4,40 +4,42 @@ When writing out a data frame, nanoparquet maps R's data types to Parquet
 logical types. The following table is a summary of the mapping. For the
 details see below.
 
-R type   | Parquet type            | Default | Notes
-:--------|:------------------------|:-------:|:----------------------------------------
-character| STRING(BYTE_ARRAY)      | x       | I.e. STRSXP. Converted to UTF-8.
-"        | BYTE_ARRAY              |         |
-"        | FIXED_LEN_BYTE_ARRAY    |         |
-"        | ENUM                    |         |
-"        | UUID                    |         |
-Date     | DATE                    | x       |
-difftime | INT64                   | x       | If not hms::hms. Arrow metadata marks it as Duration(NS).
-factor   | STRING                  | x       | Arrow metadata marks it as a factor.
-"        | ENUM                    |         |
-hms::hms | TIME(true, MILLIS)      | x       | Sub-milliseconds precision is lost.
-integer  | INT(32, true)           | x       | I.e. INTSXP.
-"        | INT64                   |         |
-"        | INT96                   |         |
-"        | DECIMAL(INT32)          |         |
-"        | DECIMAL(INT64)          |         |
-"        | INT(8, *)               |         |
-"        | INT(16, *)              |         |
-"        | INT(32, signed)         |         |
-list     | LIST(INT32 elements)    | x       | List of integer vectors. `NULL` entries and `NA` elements are supported.
-"        | LIST(DOUBLE elements)   | x       | List of double vectors. `NULL` entries and `NA` elements are supported.
-"        | LIST(STRING elements)   | x       | List of character vectors. `NULL` entries and `NA` elements are supported.
-"        | BYTE_ARRAY              |         | Must be a list of raw vectors. Missing values are `NULL`.
-"        | FIXED_LEN_BYTE_ARRAY    |         | Must be a list of raw vectors of the same length. Missing values are `NULL`.
-logical  | BOOLEAN                 | x       | I.e. LGLSXP.
-numeric  | DOUBLE                  | x       | I.e. REALSXP.
-"        | INT96                   |         |
-"        | FLOAT                   |         |
-"        | DECIMAL(INT32)          |         |
-"        | DECIMAL(INT64)          |         |
-"        | INT(*, *)               |         |
-"        | FLOAT16                 |         |
-POSIXct  | TIMESTAMP(true, MICROS) | x       | Sub-microsecond precision is lost.
+R type      | Parquet type            | Default | Notes
+:-----------|:------------------------|:-------:|:----------------------------------------
+blob::blob  | BYTE_ARRAY              | x       | Missing values are `NULL`.
+"           | FIXED_LEN_BYTE_ARRAY    |         | All entries must have the same length. Missing values are `NULL`.
+character   | STRING(BYTE_ARRAY)      | x       | I.e. STRSXP. Converted to UTF-8.
+"           | BYTE_ARRAY              |         |
+"           | FIXED_LEN_BYTE_ARRAY    |         |
+"           | ENUM                    |         |
+"           | UUID                    |         |
+Date        | DATE                    | x       |
+difftime    | INT64                   | x       | If not hms::hms. Arrow metadata marks it as Duration(NS).
+factor      | STRING                  | x       | Arrow metadata marks it as a factor.
+"           | ENUM                    |         |
+hms::hms    | TIME(true, MILLIS)      | x       | Sub-milliseconds precision is lost.
+integer     | INT(32, true)           | x       | I.e. INTSXP.
+"           | INT64                   |         |
+"           | INT96                   |         |
+"           | DECIMAL(INT32)          |         |
+"           | DECIMAL(INT64)          |         |
+"           | INT(8, *)               |         |
+"           | INT(16, *)              |         |
+"           | INT(32, signed)         |         |
+list        | LIST(INT32 elements)    | x       | List of integer vectors. `NULL` entries and `NA` elements are supported.
+"           | LIST(DOUBLE elements)   | x       | List of double vectors. `NULL` entries and `NA` elements are supported.
+"           | LIST(STRING elements)   | x       | List of character vectors. `NULL` entries and `NA` elements are supported.
+"           | BYTE_ARRAY              |         | Must be a list of raw vectors. Missing values are `NULL`.
+"           | FIXED_LEN_BYTE_ARRAY    |         | Must be a list of raw vectors of the same length. Missing values are `NULL`.
+logical     | BOOLEAN                 | x       | I.e. LGLSXP.
+numeric     | DOUBLE                  | x       | I.e. REALSXP.
+"           | INT96                   |         |
+"           | FLOAT                   |         |
+"           | DECIMAL(INT32)          |         |
+"           | DECIMAL(INT64)          |         |
+"           | INT(*, *)               |         |
+"           | FLOAT16                 |         |
+POSIXct     | TIMESTAMP(true, MICROS) | x       | Sub-microsecond precision is lost.
 
 The non-default mappings can be selected via the `schema` argument. E.g.
 to write out a factor column called 'name' as `ENUM`, use
@@ -48,6 +50,10 @@ write_parquet(..., schema = parquet_schema(name = "ENUM"))
 The detailed mapping rules are listed below, in order of preference.
 These rules will likely change until nanoparquet reaches version 1.0.0.
 
+1. `blob::blob` objects (from the blob package) are written as `BYTE_ARRAY`.
+   `blob::blob` is a list of raw vectors, and nanoparquet handles any object
+   that inherits the `blob` class this way, even if the blob package is not
+   installed. Missing values (i.e. `NULL` list entries) are supported.
 1. Factors (i.e. vectors that inherit the *factor* class) are converted
    to character vectors using `as.character()`, then written as a
    `STRSXP` (character vector) type. The fact that a column is a factor
@@ -101,7 +107,8 @@ non-default mappings are:
 - `list` of `double` vectors to `LIST` with `DOUBLE` elements,
 - `list` of `character` vectors to `LIST` with `STRING` elements,
 - `list` of `raw` vectors to `BYTE_ARRAY`,
-- `list` of `raw` vectors to `FIXED_LEN_BYTE_ARRAY`.
+- `list` of `raw` vectors to `FIXED_LEN_BYTE_ARRAY`,
+- `blob::blob` to `FIXED_LEN_BYTE_ARRAY`.
 
 # Parquet's data types
 
@@ -110,38 +117,38 @@ the Arrow metadata (if present, see below) in addition to the low level
 data types. The following table summarizes the mappings. See more details
 below.
 
-Parquet type         | R type    | Notes
-:--------------------|:----------|:---------------------------------------------
-*Logical types*      |           |
-BSON                 | character |
-DATE                 | Date      |
-DECIMAL              | numeric   | REALSXP, potentially losing precision.
-ENUM                 | character |
-FLOAT16              | numeric   | REALSXP
-INT(8, *)            | integer   |
-INT(16, *)           | integer   |
-INT(32, *)           | integer   | Large unsigned values may overflow!
-INT(64, *)           | numeric   | REALSXP
-INTERVAL             | list(raw) | Missing values are `NULL`.
-JSON                 | character |
-LIST                 | list      | Elements are read as their corresponding R type.
-MAP                  |           | Not supported.
-STRING               | factor    | If Arrow metadata says it is a factor. Also UTF8.
-"                    | character | Otherwise. Also UTF8.
-TIME                 | hms::hms  | Also TIME_MILLIS and TIME_MICROS.
-TIMESTAMP            | POSIXct   | Also TIMESTAMP_MILLIS and TIMESTAMP_MICROS.
-UUID                 | character | In `00112233-4455-6677-8899-aabbccddeeff` form.
-UNKNOWN              |           | Not supported.
-*Primitive types*    |           |
-BOOLEAN              | logical   |
-BYTE_ARRAY           | factor    | If Arrow metadata says it is a factor.
-"                    | list(raw) | Otherwise. Missing values are `NULL`.
-DOUBLE               | numeric   | REALSXP
-FIXED_LEN_BYTE_ARRAY | list(raw) | Missing values are `NULL`.
-FLOAT                | numeric   | REALSXP
-INT32                | integer   |
-INT64                | numeric   | REALSXP
-INT96                | POSIXct   |
+Parquet type         | R type     | Notes
+:--------------------|:-----------|:---------------------------------------------
+*Logical types*      |            |
+BSON                 | character  |
+DATE                 | Date       |
+DECIMAL              | numeric    | REALSXP, potentially losing precision.
+ENUM                 | character  |
+FLOAT16              | numeric    | REALSXP
+INT(8, *)            | integer    |
+INT(16, *)           | integer    |
+INT(32, *)           | integer    | Large unsigned values may overflow!
+INT(64, *)           | numeric    | REALSXP
+INTERVAL             | list(raw)  | Missing values are `NULL`.
+JSON                 | character  |
+LIST                 | list       | Elements are read as their corresponding R type.
+MAP                  |            | Not supported.
+STRING               | factor     | If Arrow metadata says it is a factor. Also UTF8.
+"                    | character  | Otherwise. Also UTF8.
+TIME                 | hms::hms   | Also TIME_MILLIS and TIME_MICROS.
+TIMESTAMP            | POSIXct    | Also TIMESTAMP_MILLIS and TIMESTAMP_MICROS.
+UUID                 | character  | In `00112233-4455-6677-8899-aabbccddeeff` form.
+UNKNOWN              |            | Not supported.
+*Primitive types*    |            |
+BOOLEAN              | logical    |
+BYTE_ARRAY           | factor     | If Arrow metadata says it is a factor.
+"                    | blob::blob | Otherwise. Missing values are `NULL`.
+DOUBLE               | numeric    | REALSXP
+FIXED_LEN_BYTE_ARRAY | blob::blob | Missing values are `NULL`.
+FLOAT                | numeric    | REALSXP
+INT32                | integer    |
+INT64                | numeric    | REALSXP
+INT96                | POSIXct    |
 
 The exact rules are below. These rules will likely change until nanoparquet
 reaches version 1.0.0.
@@ -172,8 +179,11 @@ reaches version 1.0.0.
 1. `BYTE_ARRAY` is read as a *factor* object if the file was written
    by Arrow and the original data type of the column was a factor.
    (See 'The Arrow metadata below.)
-1. Otherwise `BYTE_ARRAY` is read a list of raw vectors, with missing
-   values denoted by `NULL`.
+1. Otherwise `BYTE_ARRAY` and `FIXED_LEN_BYTE_ARRAY` are read as a
+   `blob::blob` object. `blob::blob` is a list of raw vectors with class
+   `blob` (and related vctrs classes). The blob package is not required to
+   use this object; it is simply a list of raw vectors. Missing values are
+   denoted by `NULL`.
 
 Other logical and converted types are read as their annotated low level
 types:


### PR DESCRIPTION
`read_parquet()` now returns `BYTE_ARRAY` and `FIXED_LEN_BYTE_ARRAY` columns (without a string/UUID/decimal annotation) as `blob::blob` objects
 instead of plain lists of raw vectors. `write_parquet()` now also accepts
`blob::blob` columns (#115).

Closes #115.